### PR TITLE
alineados ajustada de titulos con viñetas, texto y espaciado

### DIFF
--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -4,13 +4,13 @@ import { useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { motion } from 'motion/react'
-import { 
-  FaGithub, 
-  FaDiscord, 
-  FaFacebook, 
-  FaInstagram, 
-  FaLinkedin, 
-  FaWhatsapp 
+import {
+  FaGithub,
+  FaDiscord,
+  FaFacebook,
+  FaInstagram,
+  FaLinkedin,
+  FaWhatsapp
 } from 'react-icons/fa'
 import { MdEmail } from 'react-icons/md'
 
@@ -60,7 +60,7 @@ export default function Footer() {
     <footer className="relative bg-[var(--color-surface)] border-t-2 border-[var(--color-border)]">
       {/* Gradient overlay */}
       <div className="absolute inset-0 bg-gradient-to-b from-[var(--color-background)]/70 to-transparent pointer-events-none" />
-      
+
       <div className="container mx-auto py-16 md:py-20 relative z-10">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 lg:gap-10 mb-12">
           {/* Brand Column */}
@@ -122,7 +122,7 @@ export default function Footer() {
             viewport={{ once: true }}
             transition={{ duration: 0.5, delay: 0.1 }}
           >
-            <h3 className="text-xl font-bold mb-6 text-[var(--color-text-primary)]">
+            <h3 className="text-xl font-bold mb-6 !mx-0 text-[var(--color-text-primary)]">
               Links Rápidos
             </h3>
             <ul className="space-y-3.5">
@@ -133,7 +133,7 @@ export default function Footer() {
                     onClick={(e) => handleNavClick(e, link.href)}
                     className="text-[var(--color-text-secondary)] hover:text-[var(--color-primary)] transition-colors flex items-center gap-3 group text-base"
                   >
-                    <p className="w-2 h-2 rounded-full bg-[var(--color-primary)] group-hover:scale-150 transition-transform" />
+                    <p className="w-2 h-2 !mb-0 rounded-full bg-[var(--color-primary)] group-hover:scale-150 transition-transform" />
                     {link.label}
                   </a>
                 </li>
@@ -148,14 +148,14 @@ export default function Footer() {
             viewport={{ once: true }}
             transition={{ duration: 0.5, delay: 0.2 }}
           >
-            <h3 className="text-xl font-bold mb-6 text-[var(--color-text-primary)]">
+            <h3 className="text-xl font-bold mb-6 !mx-0 text-[var(--color-text-primary)]">
               Servicios
             </h3>
             <ul className="space-y-3.5">
               {services.map((service) => (
                 <li key={service}>
-                  <span className="text-[var(--color-text-secondary)] flex items-center gap-3 text-base">
-                    <p className="w-2 h-2 rounded-full bg-[var(--color-accent)]" />
+                  <span className="!w-full text-[var(--color-text-secondary)] flex items-center gap-3 text-base">
+                    <p className="w-2 h-2 !mb-0 rounded-full bg-[var(--color-accent)]" />
                     {service}
                   </span>
                 </li>
@@ -170,7 +170,7 @@ export default function Footer() {
             viewport={{ once: true }}
             transition={{ duration: 0.5, delay: 0.3 }}
           >
-            <h3 className="text-xl font-bold mb-6 text-[var(--color-text-primary)]">
+            <h3 className="text-xl font-bold mb-6 !mx-0 text-[var(--color-text-primary)]">
               Contacto
             </h3>
             <ul className="space-y-3">
@@ -209,7 +209,7 @@ export default function Footer() {
                 </a>
               </li>
             </ul>
-            
+
             {/* CTA */}
             <div className="mt-5">
               <motion.a
@@ -245,7 +245,7 @@ export default function Footer() {
             </Link>
           </div>
           <p className="text-[var(--color-text-secondary)] text-sm flex items-center gap-2">
-             <span className="text-red-500">Diseñado con ❤️ por Folkode</span>
+            <span className="text-red-500">Diseñado con ❤️ por Folkode</span>
           </p>
         </motion.div>
       </div>


### PR DESCRIPTION
Utilicé important para eliminar el margin en el eje X de los titulos alineandolos hacia la izquierda automaticamente
para la alineación de las viñetas tuve que sacarle el margin button en las etiquetas <p> que son los puntos, como el contenedor ya tiene un align-items center normalmente quedan alineadas.
Además ajuste el tamaño de las etiquetas de los servicios ajustando el width al 100% del contenedor para que tenga más espacio el texto y no se vea apretado