### PR TITLE
iconos separados y ajustado su espaciado y padding

### DIFF
--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -231,7 +231,7 @@ export default function Footer() {
           whileInView={{ opacity: 1 }}
           viewport={{ once: true }}
           transition={{ duration: 0.5, delay: 0.4 }}
-          className="!mt-12 !pt-8 border-t-2 border-[var(--color-border)] flex flex-col md:flex-row justify-between items-center gap-4"
+          className="mt-12 !pt-8 border-t-2 border-[var(--color-border)] flex flex-col md:flex-row justify-between items-center gap-4"
         >
           <p className="text-[var(--color-text-secondary)] text-sm">
             © {currentYear} Folkode. Todos los derechos reservados.


### PR DESCRIPTION
Elimine los margin bottom que tenian los elementos de texto de las cards y agregué padding a las cards.
Ajusté propiedades que no se renderizaban del boton cta (margins y paddings)
Hice las cards del contacto pero no estan iguales a las de la sección contáctanos porque todavia no esta hecha esa issue asi que puede que necesite ajustarlo despues a menos que las cards del footer de contacto se copien y peguen en la sección de contáctanos
