### PR TITLE
Sección alineada correctamente

### DIFF
--- a/frontend/src/components/sections/History.tsx
+++ b/frontend/src/components/sections/History.tsx
@@ -97,24 +97,24 @@ const History: React.FC = () => {
         {/* Nuestro Logo Section */}
         <div className="relative">
           <div className="absolute bottom-0 left-0 w-[500px] h-[500px] bg-[var(--color-primary)]/5 rounded-full blur-[100px] -z-10" />
-          <div className="flex flex-col lg:flex-row-reverse items-start">
+          <div className="flex flex-col lg:flex-row-reverse items-center lg:items-start">
             <div className="lg:w-1/3 flex flex-col items-center lg:items-end">
               <div className="w-16 h-16 bg-[var(--color-secondary)]/10 rounded-2xl flex items-center justify-center !mb-4 border border-[var(--color-secondary)]/20">
                 <Palette className="w-8 h-8 text-[var(--moss-green)]" />
               </div>
-              <h5 className="text-gradient font-black !tracking-[0.5em] text-[10px] uppercase mb-4 text-end">El Símbolo</h5>
-              <h3 className="text-4xl md:text-5xl font-black text-white tracking-tighter mb-6">NUESTRO <br />LOGO</h3>
+              <h5 className="text-gradient font-black !tracking-[0.5em] text-[10px] uppercase mb-4  lg:text-end">El Símbolo</h5>
+              <h3 className="text-4xl md:text-5xl font-black text-white tracking-tighter text-center !mx-0 lg:text-end">NUESTRO <br />LOGO</h3>
             </div>
-            <div className="lg:w-2/3 space-y-8">
-              <div className="card glass p-12 rounded-[4rem] border-[var(--color-border)]/10 relative overflow-hidden group">
+            <div className="w-full lg:w-2/3 space-y-8">
+              <div className="card glass !m-0 !p-8 rounded-[4rem] border-[var(--color-border)]/10 relative overflow-hidden group">
                 <div className="absolute top-0 right-0 p-12 opacity-10 group-hover:scale-110 transition-transform duration-1000">
                   <div className="w-32 h-32 bg-white/20 rounded-full blur-3xl" />
                 </div>
                 <div className="relative z-10">
-                  <h5 className="text-white font-black text-2xl mb-8 flex flex-nowrap items-center gap-4 whitespace-nowrap">
-                    <span className="w-12 !h-1 bg-[var(--color-primary)] shrink-0" />
+                  <h5 className="text-white font-black text-2xl !mb-8 flex flex-nowrap items-center gap-4 whitespace-nowrap">
+                    <span className="flex-1 !w-0 lg:w-12 !h-[2px] lg:!h-1 bg-[var(--color-primary)] shrink-0" />
                     La Cruz Pampa
-                    <span className="flex-1 !h-1 bg-[var(--color-primary)]" />
+                    <span className="flex-1 !w-0 !h-[2px] lg:!h-1 bg-[var(--color-primary)]" />
                   </h5>
                   <p className="text-[var(--color-text-secondary)] text-lg leading-relaxed mb-10">
                     Es un motivo decorativo ancestral originario de la región pampeana y patagónica de Argentina, presente en la cultura mapuche y tehuelche. Representa la conexión con la tierra y la identidad de nuestros pueblos originarios.


### PR DESCRIPTION
Centré el titulo, icono y subtitulo en mobile para que mantenga el diseño con las demás secciones.
Para hacer que se vea el contenido correctamente que estaba corrido le dí un width 100% para que ocupe el ancho del viewport en resoluciones menores de 1024px.