### PR TITLE
Menú ajustado

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -262,10 +262,10 @@ export default function Navbar() {
             {/* Social links at the bottom */}
             <div className="h-full flex flex-col items-center justify-center gap-3">
               <div className="flex gap-4">
-                {socialLinks.map((social, i) => (
+                {socialLinks.map((social) => (
                   <motion.a
-                    key={i}
-                    href="#"
+                    key={social.label}
+                    href={social.href}
                     className="p-3 bg-black/5 rounded-full text-[var(--color-text-secondary)] hover:text-[var(--color-primary)] hover:bg-white transition-all shadow-sm"
                     whileTap={{ scale: 0.9 }}
                   >
@@ -273,8 +273,8 @@ export default function Navbar() {
                   </motion.a>
                 ))}
               </div>
-              <div className="text-right">
-                <p className="text-[10px] font-medium text-[var(--color-text-secondary)] opacity-50 uppercase tracking-widest">© 2024 Folkode Studio</p>
+              <div className="text-center">
+                <p className="text-[10px] font-medium text-[var(--color-text-secondary)] opacity-50 uppercase tracking-widest">© 2026 Folkode Todos los derechos reservados.</p>
               </div>
             </div>
           </motion.div>


### PR DESCRIPTION
Ajusté el diseño para que ocupe toda la pantalla con un height 90vh (no puede ser 100vh porque el header ocupa espacio lo que haría que la parte de abajo del menú no se visualize), añadí un poco de diseño sacando el fondo del boton activo que tenía por ninguno y aplicando solo el color y una flecha en el mismo eje centrado del botón activo.
Añadí las redes sociales y el texto de copyright