### PR TITLE
feat: add DELETE/API/PROJETS/:ID

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -426,6 +426,35 @@ app.post("/api/projects", requireAdmin, async (req, res) => {
     return res.status(500).json({ error: "Error al crear el proyecto" });
   }
 });
+// DELETE /api/projects/:id - Eliminar proyecto
+app.delete("/api/projects/:id", requireAdmin, async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    // Verificar existencia
+    const existingProject = await prisma.project.findUnique({
+      where: { id },
+    });
+
+    if (!existingProject) {
+      return res.status(404).json({ error: "Proyecto no encontrado" });
+    }
+
+    // Eliminar
+    await prisma.project.delete({
+      where: { id },
+    });
+
+    // Confirmación
+    return res.json({
+      message: "Proyecto eliminado correctamente",
+      id,
+    });
+  } catch (error) {
+    console.error("Error al eliminar proyecto:", error);
+    return res.status(500).json({ error: "Error al eliminar el proyecto" });
+  }
+});
 
 const PORT = process.env.PORT || 4000;
 app.listen(PORT, () => {


### PR DESCRIPTION
Descripción:
-Implementado DELETE /api/projects/:id para eliminar un proyecto existente.
-Protegido con requireAdmin (JWT + rol ADMIN).

Resultados esperados:
-Elimina proyecto por ID.
-Retorna confirmación.
-404 si no existe.
-Manejo de error 500 ante fallas.
-Requiere autenticación ADMIN.

Pruebas:
-DELETE con ID existente: OK
-DELETE con ID inexistente: 404
-Sin token: 401
-Usuario sin ADMIN: 403